### PR TITLE
Add job routines and richer civilian intents

### DIFF
--- a/js/prefabs/Pedestrian.js
+++ b/js/prefabs/Pedestrian.js
@@ -13,6 +13,8 @@ Pedestrian = function (game, y, sprite) {
   this.visible = true;
 
   this.ai = new Brain(game);
+  this.currentIntent = this.ai.chooseIntent();
+  this.goal = this.currentIntent.goal;
 
   this.direction = this.setDirection();
   this.sprite_message = "";
@@ -64,12 +66,13 @@ Pedestrian.prototype.spriteMessage = function () {
     var message = "";
     // console.log(this.isMoving);
     if(this.isMoving){
-      message = this.ai.thoughts.needs[0].maslow[0].emotion;
+      message = this.currentIntent && this.currentIntent.message ? this.currentIntent.message : this.ai.thoughts.needs[0].maslow[0].emotion;
     }else{
       message = "Thinking...";
     }
 
-    this.sprite_message = this.game.add.bitmapText(this.centerX, this.y - this.height / 2, 'smallfont', message, 18);
+    var walletText = " ($" + this.ai.profile.wallet + ")";
+    this.sprite_message = this.game.add.bitmapText(this.centerX, this.y - this.height / 2, 'smallfont', message + walletText, 18);
     this.sprite_message.anchor.setTo(0.5,0.5);
   }
 
@@ -77,14 +80,15 @@ Pedestrian.prototype.spriteMessage = function () {
 };
 Pedestrian.prototype.removePedestrian = function (next, sprite) {
   sprite.visible = false;
-  sprite.ai.thoughts.needs[0].maslow[0].value = 0;
+  sprite.ai.resolveIntent(sprite.currentIntent);
   var timer = sprite.game.time.events.add(Phaser.Timer.SECOND*4, next, sprite);
 
 };
 
 Pedestrian.prototype.putBack = function () {
   this.visible = true;
-  this.goal = this.ai.setGoal();
+  this.currentIntent = this.ai.chooseIntent();
+  this.goal = this.currentIntent.goal;
 
 };
 
@@ -271,7 +275,9 @@ Pedestrian.prototype.update = function () {
   }else{
     if(this.isWaiting() === true){
       // console.log("not walking");
-      this.goal = this.ai.setGoal();
+      this.currentIntent = this.ai.chooseIntent();
+      this.goal = this.currentIntent.goal;
+      this.direction = this.setDirection();
       this.anim = this.anim.replace("-wait", "-walk");
 
       this.check_animation();


### PR DESCRIPTION
## Summary
- extend pedestrian brains with personal profiles, wallets, and work schedules
- choose goals based on routine, finances, and need urgency to feel more lifelike
- display intent messages with wallet info and resolve activities into earnings or spending

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69225488d0388327b3d391297769a665)