### PR TITLE
Add city economy simulation and integrate with Brain/Game

### DIFF
--- a/js/Game.js
+++ b/js/Game.js
@@ -6,6 +6,7 @@ var DayCycle = require('./prefabs/DayCycle');
 var Car = require('./prefabs/Car');
 var Hud = require('./prefabs/Hud');
 var City = require('./prefabs/City');
+var Economy = require('./sim/Economy');
 
 
 Uberman.Game = function (game) {
@@ -193,6 +194,8 @@ Uberman.Game.prototype = {
 
 
 
+    this.game.economy = new Economy(this.game);
+
     var pedestrians = this.game.add.group();
     for (var i = 0; i < this.numpredestrians; i++) {
       var pedestrian = new Pedestrian(this.game, this.game.world.height - 260, "pedestrian");
@@ -216,6 +219,9 @@ Uberman.Game.prototype = {
   update: function () {
 
     this.game.physics.arcade.collide(this.game.player, platforms);
+    if (this.game.economy) {
+      this.game.economy.update(this.game.time.elapsedMS || 16);
+    }
     this.city.update();
 
   },

--- a/js/prefabs/Brain.js
+++ b/js/prefabs/Brain.js
@@ -317,6 +317,13 @@ BRAIN.prototype.isWorkingHour = function (hour) {
 };
 
 BRAIN.prototype.getNeedCost = function (need) {
+  var economy = this.game && this.game.economy;
+  if (economy && economy.needVenueMap && economy.needVenueMap[need]) {
+    var venueSnapshot = economy.getVenueSnapshot(economy.needVenueMap[need]);
+    if (venueSnapshot && venueSnapshot.price !== undefined) {
+      return venueSnapshot.price;
+    }
+  }
   var costs = {
     WATER: 3,
     FOOD: 6,
@@ -332,6 +339,23 @@ BRAIN.prototype.hasBudgetFor = function (needName) {
   var cost = this.getNeedCost(needName);
   var reserve = Math.floor(this.profile.savingsGoal * 0.5);
   return (this.profile.wallet - cost) >= reserve;
+};
+
+BRAIN.prototype.getEconomy = function () {
+  return this.game && this.game.economy ? this.game.economy : null;
+};
+
+BRAIN.prototype.attachServiceQuote = function (intent) {
+  if (!intent) {
+    return intent;
+  }
+  var economy = this.getEconomy();
+  if (!economy) {
+    intent.quote = { ok: true, price: this.getNeedCost(intent.need), reason: 'legacy' };
+    return intent;
+  }
+  intent.quote = economy.requestService(intent, this.profile);
+  return intent;
 };
 
 BRAIN.prototype.findNeedByName = function (name) {
@@ -435,7 +459,7 @@ BRAIN.prototype.describeIntent = function (type, data) {
   }
   if (type === 'FULFILL_NEED' && data && data.need) {
     var thought = this.composeNeedThought(data.need, data.emotion);
-    var cost = this.getNeedCost(data.need);
+    var cost = data.price !== undefined ? data.price : this.getNeedCost(data.need);
     return cost ? thought + ' ($' + cost + ')' : thought;
   }
   return data && data.emotion ? data.emotion : 'On the move';
@@ -530,7 +554,7 @@ BRAIN.prototype.chooseIntent = function () {
   if (approachingShift && this.profile.fatigue < 90) {
     var workIntent = this.buildIntent('WORK', this.profile.workplace, this.game.world.centerX, 'Heading to work', 'MONEY');
     workIntent.message = this.describeIntent('WORK', { need: 'MONEY' });
-    return workIntent;
+    return this.attachServiceQuote(workIntent);
   }
 
   if (this.profile.fatigue > 80 || hour >= 22 || hour < 6) {
@@ -543,11 +567,12 @@ BRAIN.prototype.chooseIntent = function () {
   if (!this.hasBudgetFor(topNeed.need) && topNeed.need !== 'MONEY') {
     var brokeIntent = this.buildIntent('WORK', this.profile.workplace, this.game.world.centerX, "I need cash first", 'MONEY');
     brokeIntent.message = this.describeIntent('WORK', { need: 'MONEY' });
-    return brokeIntent;
+    return this.attachServiceQuote(brokeIntent);
   }
   var doorKey = topNeed.acts[0].toLowerCase();
   var intent = this.buildIntent('FULFILL_NEED', doorKey, this.game.world.centerX, topNeed.emotion, topNeed.need);
-  intent.message = this.describeIntent('FULFILL_NEED', { need: topNeed.need, emotion: topNeed.emotion });
+  intent = this.attachServiceQuote(intent);
+  intent.message = this.describeIntent('FULFILL_NEED', { need: topNeed.need, emotion: topNeed.emotion, price: intent.quote && intent.quote.price });
   return intent;
 };
 
@@ -555,10 +580,18 @@ BRAIN.prototype.resolveIntent = function (intent) {
   if (!intent) {
     return;
   }
+  var economy = this.getEconomy();
+  var settlement = null;
+  if (economy) {
+    settlement = economy.settleTransaction(intent, this.profile);
+    this.profile.wallet = Math.max(0, this.profile.wallet + settlement.walletDelta);
+  }
   if (intent.type === 'WORK') {
-    this.profile.wallet += this.profile.income;
+    if (!economy) {
+      this.profile.wallet += this.profile.income;
+    }
     var moneyNeed = this.findNeedByName('MONEY');
-    if (moneyNeed) {
+    if (moneyNeed && (!settlement || settlement.ok)) {
       moneyNeed.value = 0;
     }
     this.profile.fatigue = Math.min(100, this.profile.fatigue + 5);
@@ -566,11 +599,15 @@ BRAIN.prototype.resolveIntent = function (intent) {
 
   if (intent.type === 'FULFILL_NEED' && intent.need) {
     var need = this.findNeedByName(intent.need);
-    if (need) {
+    if (need && (!settlement || settlement.ok)) {
       need.value = 0;
+      this.profile.fatigue = Math.max(0, this.profile.fatigue - 2);
+    } else if (need && settlement && !settlement.ok) {
+      need.value += 2;
+    }
+    if (!economy && need) {
       var cost = this.getNeedCost(intent.need);
       this.profile.wallet = Math.max(0, this.profile.wallet - cost);
-      this.profile.fatigue = Math.max(0, this.profile.fatigue - 2);
     }
   }
 
@@ -581,6 +618,7 @@ BRAIN.prototype.resolveIntent = function (intent) {
     }
     this.profile.fatigue = Math.max(0, this.profile.fatigue - 25);
   }
+  intent.outcome = settlement;
   this.profile.lastIntent = intent;
 };
 

--- a/js/sim/Economy.js
+++ b/js/sim/Economy.js
@@ -1,0 +1,378 @@
+var Economy = function (game) {
+  this.game = game;
+  this.rebalanceIntervalMs = 12000;
+  this.timeSinceRebalance = 0;
+  this.lastRebalanceAt = 0;
+
+  this.venueOrder = ['bank', 'bakery', 'cafe', 'library', 'bookstore'];
+  this.needVenueMap = {
+    WATER: 'cafe',
+    FOOD: 'bakery',
+    SECURITY: 'library',
+    MONEY: 'bank',
+    WARMTH: 'library',
+    FRIENDSHIP: 'bank',
+    INTIMACY: 'library',
+    FAMILY: 'bank',
+    CONFIDENCE: 'library',
+    ART: 'bookstore',
+    EDUCATION: 'library'
+  };
+
+  this.venues = {
+    bank: this.createVenue('bank', {
+      serviceCapacity: 4,
+      tellerSlots: 4,
+      basePrice: 1,
+      wage: 16,
+      staffCount: 3,
+      inventoryMax: 0,
+      restockUnitCost: 0,
+      openingBalance: 450
+    }),
+    bakery: this.createVenue('bakery', {
+      serviceCapacity: 7,
+      seats: 6,
+      basePrice: 6,
+      wage: 11,
+      staffCount: 2,
+      inventoryMax: 36,
+      inventory: 18,
+      restockUnitCost: 2,
+      openingBalance: 220
+    }),
+    cafe: this.createVenue('cafe', {
+      serviceCapacity: 8,
+      seats: 8,
+      basePrice: 4,
+      wage: 10,
+      staffCount: 2,
+      inventoryMax: 44,
+      inventory: 22,
+      restockUnitCost: 2,
+      openingBalance: 220
+    }),
+    library: this.createVenue('library', {
+      serviceCapacity: 9,
+      seats: 12,
+      basePrice: 3,
+      wage: 9,
+      staffCount: 2,
+      inventoryMax: 22,
+      inventory: 16,
+      restockUnitCost: 1,
+      openingBalance: 260
+    }),
+    bookstore: this.createVenue('bookstore', {
+      serviceCapacity: 5,
+      seats: 4,
+      basePrice: 8,
+      wage: 10,
+      staffCount: 2,
+      inventoryMax: 28,
+      inventory: 12,
+      restockUnitCost: 3,
+      openingBalance: 240
+    })
+  };
+};
+
+Economy.prototype.createVenue = function (key, options) {
+  var venue = {
+    key: key,
+    open: true,
+    serviceCapacity: options.serviceCapacity || 1,
+    tellerSlots: options.tellerSlots || 0,
+    seats: options.seats || 0,
+    inventoryMax: options.inventoryMax || 0,
+    inventory: options.inventory || 0,
+    basePrice: options.basePrice || 1,
+    dynamicPrice: options.basePrice || 1,
+    restockUnitCost: options.restockUnitCost || 0,
+    wage: options.wage || 0,
+    staffCount: options.staffCount || 1,
+    balance: options.openingBalance || 0,
+    demandPressure: 0,
+    cycleRequests: 0,
+    cycleServed: 0,
+    cycleFailures: 0,
+    accounting: {
+      revenue: 0,
+      expenses: 0,
+      payroll: 0,
+      restock: 0,
+      transactions: 0,
+      failedRequests: 0
+    }
+  };
+  venue.dynamicPrice = this.computeDynamicPrice(venue);
+  return venue;
+};
+
+Economy.prototype.resolveVenueForIntent = function (intent) {
+  if (!intent) {
+    return null;
+  }
+  if (intent.door && this.venues[intent.door]) {
+    return intent.door;
+  }
+  if (intent.need && this.needVenueMap[intent.need]) {
+    return this.needVenueMap[intent.need];
+  }
+  return null;
+};
+
+Economy.prototype.computeDynamicPrice = function (venue) {
+  var shortageRatio = 0;
+  if (venue.inventoryMax > 0) {
+    shortageRatio = 1 - (venue.inventory / venue.inventoryMax);
+    shortageRatio = Math.max(0, Math.min(1, shortageRatio));
+  }
+  var pressure = Math.max(0, Math.min(2, venue.demandPressure));
+  var multiplier = 1 + (shortageRatio * 0.8) + (pressure * 0.45);
+  var minPrice = venue.basePrice * 0.6;
+  var maxPrice = venue.basePrice * 2.5;
+  return Math.max(minPrice, Math.min(maxPrice, venue.basePrice * multiplier));
+};
+
+Economy.prototype.hasCapacity = function (venue) {
+  return venue.cycleRequests <= venue.serviceCapacity;
+};
+
+Economy.prototype.hasInventory = function (venue, intent) {
+  if (!intent || intent.type !== 'FULFILL_NEED') {
+    return true;
+  }
+  if (venue.inventoryMax <= 0) {
+    return true;
+  }
+  return venue.inventory > 0;
+};
+
+Economy.prototype.requestService = function (intent, actorProfile) {
+  var venueKey = this.resolveVenueForIntent(intent);
+  var quote = {
+    ok: false,
+    venue: venueKey,
+    price: 0,
+    reason: 'no_venue',
+    capacity: 0,
+    inventory: 0,
+    open: false
+  };
+
+  if (!venueKey || !this.venues[venueKey]) {
+    return quote;
+  }
+
+  var venue = this.venues[venueKey];
+  venue.cycleRequests += 1;
+  venue.dynamicPrice = this.computeDynamicPrice(venue);
+
+  quote.capacity = Math.max(0, venue.serviceCapacity - venue.cycleRequests);
+  quote.inventory = venue.inventory;
+  quote.open = venue.open;
+  quote.price = Math.ceil(venue.dynamicPrice);
+
+  if (!venue.open) {
+    venue.cycleFailures += 1;
+    venue.accounting.failedRequests += 1;
+    quote.reason = 'closed';
+    return quote;
+  }
+
+  if (!this.hasCapacity(venue)) {
+    venue.cycleFailures += 1;
+    venue.accounting.failedRequests += 1;
+    quote.reason = 'capacity';
+    return quote;
+  }
+
+  if (!this.hasInventory(venue, intent)) {
+    venue.cycleFailures += 1;
+    venue.accounting.failedRequests += 1;
+    quote.reason = 'stock';
+    return quote;
+  }
+
+  if (intent && intent.type === 'WORK') {
+    quote.price = venue.wage;
+  }
+
+  quote.ok = true;
+  quote.reason = 'ok';
+  return quote;
+};
+
+Economy.prototype.applyRevenue = function (venue, amount) {
+  venue.balance += amount;
+  venue.accounting.revenue += amount;
+};
+
+Economy.prototype.applyExpense = function (venue, amount, expenseType) {
+  venue.balance -= amount;
+  venue.accounting.expenses += amount;
+  if (expenseType && venue.accounting[expenseType] !== undefined) {
+    venue.accounting[expenseType] += amount;
+  }
+};
+
+Economy.prototype.settleTransaction = function (intent, actorProfile) {
+  var outcome = {
+    ok: false,
+    walletDelta: 0,
+    venue: null,
+    reason: 'no_transaction',
+    price: 0
+  };
+
+  if (!intent) {
+    return outcome;
+  }
+
+  if (intent.type === 'REST') {
+    outcome.ok = true;
+    outcome.reason = 'rested';
+    return outcome;
+  }
+
+  var venueKey = this.resolveVenueForIntent(intent);
+  if (!venueKey || !this.venues[venueKey]) {
+    outcome.reason = 'no_venue';
+    return outcome;
+  }
+
+  var venue = this.venues[venueKey];
+  var quote = intent.quote || this.requestService(intent, actorProfile);
+  outcome.venue = venueKey;
+  outcome.price = quote.price || 0;
+
+  if (!quote.ok) {
+    outcome.reason = quote.reason;
+    return outcome;
+  }
+
+  if (intent.type === 'WORK') {
+    var wage = Math.max(1, quote.price || venue.wage);
+    outcome.ok = true;
+    outcome.walletDelta = wage;
+    outcome.reason = 'paid';
+
+    this.applyExpense(venue, wage, 'payroll');
+    venue.cycleServed += 1;
+    venue.accounting.transactions += 1;
+    return outcome;
+  }
+
+  var price = Math.max(0, quote.price || Math.ceil(venue.dynamicPrice));
+  if (!actorProfile || actorProfile.wallet < price) {
+    venue.cycleFailures += 1;
+    venue.accounting.failedRequests += 1;
+    outcome.reason = 'insufficient_funds';
+    outcome.price = price;
+    return outcome;
+  }
+
+  if (!this.hasInventory(venue, intent)) {
+    venue.cycleFailures += 1;
+    venue.accounting.failedRequests += 1;
+    outcome.reason = 'stock';
+    return outcome;
+  }
+
+  outcome.ok = true;
+  outcome.walletDelta = -price;
+  outcome.reason = 'served';
+  outcome.price = price;
+
+  if (venue.inventoryMax > 0) {
+    venue.inventory = Math.max(0, venue.inventory - 1);
+  }
+
+  this.applyRevenue(venue, price);
+  venue.cycleServed += 1;
+  venue.accounting.transactions += 1;
+
+  return outcome;
+};
+
+Economy.prototype.rebalanceVenue = function (venue) {
+  var shortageRatio = 0;
+  if (venue.inventoryMax > 0) {
+    shortageRatio = 1 - (venue.inventory / venue.inventoryMax);
+  }
+
+  var demandSignal = 0;
+  if (venue.cycleRequests > 0) {
+    demandSignal = (venue.cycleRequests - venue.cycleServed) / venue.cycleRequests;
+  }
+
+  venue.demandPressure = (venue.demandPressure * 0.6) + (Math.max(0, demandSignal) * 0.8);
+
+  if (venue.inventoryMax > 0) {
+    var target = Math.ceil(venue.inventoryMax * 0.65);
+    if (shortageRatio > 0.45) {
+      target = Math.ceil(venue.inventoryMax * 0.85);
+    }
+    var deficit = Math.max(0, target - venue.inventory);
+    if (deficit > 0) {
+      var restockAmount = Math.max(1, Math.min(deficit, Math.ceil(venue.serviceCapacity + venue.demandPressure * 4)));
+      var restockCost = restockAmount * venue.restockUnitCost;
+      venue.inventory = Math.min(venue.inventoryMax, venue.inventory + restockAmount);
+      this.applyExpense(venue, restockCost, 'restock');
+    }
+  }
+
+  var baselinePayroll = Math.ceil(venue.wage * venue.staffCount * 0.35);
+  if (baselinePayroll > 0) {
+    this.applyExpense(venue, baselinePayroll, 'payroll');
+  }
+
+  if (venue.balance < -120 && venue.inventoryMax > 0) {
+    venue.open = false;
+  } else if (venue.balance > -30) {
+    venue.open = true;
+  }
+
+  venue.dynamicPrice = this.computeDynamicPrice(venue);
+  venue.cycleRequests = 0;
+  venue.cycleServed = 0;
+  venue.cycleFailures = 0;
+};
+
+Economy.prototype.rebalance = function () {
+  for (var i = 0; i < this.venueOrder.length; i++) {
+    var key = this.venueOrder[i];
+    this.rebalanceVenue(this.venues[key]);
+  }
+  this.lastRebalanceAt = this.game.time.now;
+};
+
+Economy.prototype.update = function (deltaMs) {
+  this.timeSinceRebalance += deltaMs || 16;
+  if (this.timeSinceRebalance >= this.rebalanceIntervalMs) {
+    this.timeSinceRebalance = 0;
+    this.rebalance();
+  }
+};
+
+Economy.prototype.getVenueSnapshot = function (key) {
+  var venue = this.venues[key];
+  if (!venue) {
+    return null;
+  }
+  return {
+    open: venue.open,
+    inventory: venue.inventory,
+    inventoryMax: venue.inventoryMax,
+    capacity: venue.serviceCapacity,
+    demandPressure: venue.demandPressure,
+    price: Math.ceil(venue.dynamicPrice),
+    accounting: venue.accounting,
+    balance: venue.balance,
+    seats: venue.seats,
+    tellerSlots: venue.tellerSlots
+  };
+};
+
+module.exports = Economy;

--- a/static/bundle.js
+++ b/static/bundle.js
@@ -47,6 +47,7 @@ var DayCycle = require('./prefabs/DayCycle');
 var Car = require('./prefabs/Car');
 var Hud = require('./prefabs/Hud');
 var City = require('./prefabs/City');
+var Economy = require('./sim/Economy');
 
 
 Uberman.Game = function (game) {
@@ -234,6 +235,8 @@ Uberman.Game.prototype = {
 
 
 
+    this.game.economy = new Economy(this.game);
+
     var pedestrians = this.game.add.group();
     for (var i = 0; i < this.numpredestrians; i++) {
       var pedestrian = new Pedestrian(this.game, this.game.world.height - 260, "pedestrian");
@@ -257,6 +260,9 @@ Uberman.Game.prototype = {
   update: function () {
 
     this.game.physics.arcade.collide(this.game.player, platforms);
+    if (this.game.economy) {
+      this.game.economy.update(this.game.time.elapsedMS || 16);
+    }
     this.city.update();
 
   },
@@ -267,7 +273,7 @@ Uberman.Game.prototype = {
 };
 
 module.exports = Uberman.Game;
-},{"./prefabs/Car":7,"./prefabs/City":8,"./prefabs/DayCycle":9,"./prefabs/Hero":10,"./prefabs/Hud":11,"./prefabs/Pedestrian":12}],3:[function(require,module,exports){
+},{"./prefabs/Car":7,"./prefabs/City":8,"./prefabs/DayCycle":9,"./prefabs/Hero":10,"./prefabs/Hud":11,"./prefabs/Pedestrian":12,"./sim/Economy":13}],3:[function(require,module,exports){
 var Uberman = Uberman || {};
 
 
@@ -788,6 +794,13 @@ BRAIN.prototype.isWorkingHour = function (hour) {
 };
 
 BRAIN.prototype.getNeedCost = function (need) {
+  var economy = this.game && this.game.economy;
+  if (economy && economy.needVenueMap && economy.needVenueMap[need]) {
+    var venueSnapshot = economy.getVenueSnapshot(economy.needVenueMap[need]);
+    if (venueSnapshot && venueSnapshot.price !== undefined) {
+      return venueSnapshot.price;
+    }
+  }
   var costs = {
     WATER: 3,
     FOOD: 6,
@@ -803,6 +816,23 @@ BRAIN.prototype.hasBudgetFor = function (needName) {
   var cost = this.getNeedCost(needName);
   var reserve = Math.floor(this.profile.savingsGoal * 0.5);
   return (this.profile.wallet - cost) >= reserve;
+};
+
+BRAIN.prototype.getEconomy = function () {
+  return this.game && this.game.economy ? this.game.economy : null;
+};
+
+BRAIN.prototype.attachServiceQuote = function (intent) {
+  if (!intent) {
+    return intent;
+  }
+  var economy = this.getEconomy();
+  if (!economy) {
+    intent.quote = { ok: true, price: this.getNeedCost(intent.need), reason: 'legacy' };
+    return intent;
+  }
+  intent.quote = economy.requestService(intent, this.profile);
+  return intent;
 };
 
 BRAIN.prototype.findNeedByName = function (name) {
@@ -906,7 +936,7 @@ BRAIN.prototype.describeIntent = function (type, data) {
   }
   if (type === 'FULFILL_NEED' && data && data.need) {
     var thought = this.composeNeedThought(data.need, data.emotion);
-    var cost = this.getNeedCost(data.need);
+    var cost = data.price !== undefined ? data.price : this.getNeedCost(data.need);
     return cost ? thought + ' ($' + cost + ')' : thought;
   }
   return data && data.emotion ? data.emotion : 'On the move';
@@ -1001,7 +1031,7 @@ BRAIN.prototype.chooseIntent = function () {
   if (approachingShift && this.profile.fatigue < 90) {
     var workIntent = this.buildIntent('WORK', this.profile.workplace, this.game.world.centerX, 'Heading to work', 'MONEY');
     workIntent.message = this.describeIntent('WORK', { need: 'MONEY' });
-    return workIntent;
+    return this.attachServiceQuote(workIntent);
   }
 
   if (this.profile.fatigue > 80 || hour >= 22 || hour < 6) {
@@ -1014,11 +1044,12 @@ BRAIN.prototype.chooseIntent = function () {
   if (!this.hasBudgetFor(topNeed.need) && topNeed.need !== 'MONEY') {
     var brokeIntent = this.buildIntent('WORK', this.profile.workplace, this.game.world.centerX, "I need cash first", 'MONEY');
     brokeIntent.message = this.describeIntent('WORK', { need: 'MONEY' });
-    return brokeIntent;
+    return this.attachServiceQuote(brokeIntent);
   }
   var doorKey = topNeed.acts[0].toLowerCase();
   var intent = this.buildIntent('FULFILL_NEED', doorKey, this.game.world.centerX, topNeed.emotion, topNeed.need);
-  intent.message = this.describeIntent('FULFILL_NEED', { need: topNeed.need, emotion: topNeed.emotion });
+  intent = this.attachServiceQuote(intent);
+  intent.message = this.describeIntent('FULFILL_NEED', { need: topNeed.need, emotion: topNeed.emotion, price: intent.quote && intent.quote.price });
   return intent;
 };
 
@@ -1026,10 +1057,18 @@ BRAIN.prototype.resolveIntent = function (intent) {
   if (!intent) {
     return;
   }
+  var economy = this.getEconomy();
+  var settlement = null;
+  if (economy) {
+    settlement = economy.settleTransaction(intent, this.profile);
+    this.profile.wallet = Math.max(0, this.profile.wallet + settlement.walletDelta);
+  }
   if (intent.type === 'WORK') {
-    this.profile.wallet += this.profile.income;
+    if (!economy) {
+      this.profile.wallet += this.profile.income;
+    }
     var moneyNeed = this.findNeedByName('MONEY');
-    if (moneyNeed) {
+    if (moneyNeed && (!settlement || settlement.ok)) {
       moneyNeed.value = 0;
     }
     this.profile.fatigue = Math.min(100, this.profile.fatigue + 5);
@@ -1037,11 +1076,15 @@ BRAIN.prototype.resolveIntent = function (intent) {
 
   if (intent.type === 'FULFILL_NEED' && intent.need) {
     var need = this.findNeedByName(intent.need);
-    if (need) {
+    if (need && (!settlement || settlement.ok)) {
       need.value = 0;
+      this.profile.fatigue = Math.max(0, this.profile.fatigue - 2);
+    } else if (need && settlement && !settlement.ok) {
+      need.value += 2;
+    }
+    if (!economy && need) {
       var cost = this.getNeedCost(intent.need);
       this.profile.wallet = Math.max(0, this.profile.wallet - cost);
-      this.profile.fatigue = Math.max(0, this.profile.fatigue - 2);
     }
   }
 
@@ -1052,6 +1095,7 @@ BRAIN.prototype.resolveIntent = function (intent) {
     }
     this.profile.fatigue = Math.max(0, this.profile.fatigue - 25);
   }
+  intent.outcome = settlement;
   this.profile.lastIntent = intent;
 };
 
@@ -2361,4 +2405,384 @@ Pedestrian.prototype.update = function () {
 
 module.exports = Pedestrian;
 
-},{"./Brain":6}]},{},[5]);
+},{"./Brain":6}],13:[function(require,module,exports){
+var Economy = function (game) {
+  this.game = game;
+  this.rebalanceIntervalMs = 12000;
+  this.timeSinceRebalance = 0;
+  this.lastRebalanceAt = 0;
+
+  this.venueOrder = ['bank', 'bakery', 'cafe', 'library', 'bookstore'];
+  this.needVenueMap = {
+    WATER: 'cafe',
+    FOOD: 'bakery',
+    SECURITY: 'library',
+    MONEY: 'bank',
+    WARMTH: 'library',
+    FRIENDSHIP: 'bank',
+    INTIMACY: 'library',
+    FAMILY: 'bank',
+    CONFIDENCE: 'library',
+    ART: 'bookstore',
+    EDUCATION: 'library'
+  };
+
+  this.venues = {
+    bank: this.createVenue('bank', {
+      serviceCapacity: 4,
+      tellerSlots: 4,
+      basePrice: 1,
+      wage: 16,
+      staffCount: 3,
+      inventoryMax: 0,
+      restockUnitCost: 0,
+      openingBalance: 450
+    }),
+    bakery: this.createVenue('bakery', {
+      serviceCapacity: 7,
+      seats: 6,
+      basePrice: 6,
+      wage: 11,
+      staffCount: 2,
+      inventoryMax: 36,
+      inventory: 18,
+      restockUnitCost: 2,
+      openingBalance: 220
+    }),
+    cafe: this.createVenue('cafe', {
+      serviceCapacity: 8,
+      seats: 8,
+      basePrice: 4,
+      wage: 10,
+      staffCount: 2,
+      inventoryMax: 44,
+      inventory: 22,
+      restockUnitCost: 2,
+      openingBalance: 220
+    }),
+    library: this.createVenue('library', {
+      serviceCapacity: 9,
+      seats: 12,
+      basePrice: 3,
+      wage: 9,
+      staffCount: 2,
+      inventoryMax: 22,
+      inventory: 16,
+      restockUnitCost: 1,
+      openingBalance: 260
+    }),
+    bookstore: this.createVenue('bookstore', {
+      serviceCapacity: 5,
+      seats: 4,
+      basePrice: 8,
+      wage: 10,
+      staffCount: 2,
+      inventoryMax: 28,
+      inventory: 12,
+      restockUnitCost: 3,
+      openingBalance: 240
+    })
+  };
+};
+
+Economy.prototype.createVenue = function (key, options) {
+  var venue = {
+    key: key,
+    open: true,
+    serviceCapacity: options.serviceCapacity || 1,
+    tellerSlots: options.tellerSlots || 0,
+    seats: options.seats || 0,
+    inventoryMax: options.inventoryMax || 0,
+    inventory: options.inventory || 0,
+    basePrice: options.basePrice || 1,
+    dynamicPrice: options.basePrice || 1,
+    restockUnitCost: options.restockUnitCost || 0,
+    wage: options.wage || 0,
+    staffCount: options.staffCount || 1,
+    balance: options.openingBalance || 0,
+    demandPressure: 0,
+    cycleRequests: 0,
+    cycleServed: 0,
+    cycleFailures: 0,
+    accounting: {
+      revenue: 0,
+      expenses: 0,
+      payroll: 0,
+      restock: 0,
+      transactions: 0,
+      failedRequests: 0
+    }
+  };
+  venue.dynamicPrice = this.computeDynamicPrice(venue);
+  return venue;
+};
+
+Economy.prototype.resolveVenueForIntent = function (intent) {
+  if (!intent) {
+    return null;
+  }
+  if (intent.door && this.venues[intent.door]) {
+    return intent.door;
+  }
+  if (intent.need && this.needVenueMap[intent.need]) {
+    return this.needVenueMap[intent.need];
+  }
+  return null;
+};
+
+Economy.prototype.computeDynamicPrice = function (venue) {
+  var shortageRatio = 0;
+  if (venue.inventoryMax > 0) {
+    shortageRatio = 1 - (venue.inventory / venue.inventoryMax);
+    shortageRatio = Math.max(0, Math.min(1, shortageRatio));
+  }
+  var pressure = Math.max(0, Math.min(2, venue.demandPressure));
+  var multiplier = 1 + (shortageRatio * 0.8) + (pressure * 0.45);
+  var minPrice = venue.basePrice * 0.6;
+  var maxPrice = venue.basePrice * 2.5;
+  return Math.max(minPrice, Math.min(maxPrice, venue.basePrice * multiplier));
+};
+
+Economy.prototype.hasCapacity = function (venue) {
+  return venue.cycleRequests <= venue.serviceCapacity;
+};
+
+Economy.prototype.hasInventory = function (venue, intent) {
+  if (!intent || intent.type !== 'FULFILL_NEED') {
+    return true;
+  }
+  if (venue.inventoryMax <= 0) {
+    return true;
+  }
+  return venue.inventory > 0;
+};
+
+Economy.prototype.requestService = function (intent, actorProfile) {
+  var venueKey = this.resolveVenueForIntent(intent);
+  var quote = {
+    ok: false,
+    venue: venueKey,
+    price: 0,
+    reason: 'no_venue',
+    capacity: 0,
+    inventory: 0,
+    open: false
+  };
+
+  if (!venueKey || !this.venues[venueKey]) {
+    return quote;
+  }
+
+  var venue = this.venues[venueKey];
+  venue.cycleRequests += 1;
+  venue.dynamicPrice = this.computeDynamicPrice(venue);
+
+  quote.capacity = Math.max(0, venue.serviceCapacity - venue.cycleRequests);
+  quote.inventory = venue.inventory;
+  quote.open = venue.open;
+  quote.price = Math.ceil(venue.dynamicPrice);
+
+  if (!venue.open) {
+    venue.cycleFailures += 1;
+    venue.accounting.failedRequests += 1;
+    quote.reason = 'closed';
+    return quote;
+  }
+
+  if (!this.hasCapacity(venue)) {
+    venue.cycleFailures += 1;
+    venue.accounting.failedRequests += 1;
+    quote.reason = 'capacity';
+    return quote;
+  }
+
+  if (!this.hasInventory(venue, intent)) {
+    venue.cycleFailures += 1;
+    venue.accounting.failedRequests += 1;
+    quote.reason = 'stock';
+    return quote;
+  }
+
+  if (intent && intent.type === 'WORK') {
+    quote.price = venue.wage;
+  }
+
+  quote.ok = true;
+  quote.reason = 'ok';
+  return quote;
+};
+
+Economy.prototype.applyRevenue = function (venue, amount) {
+  venue.balance += amount;
+  venue.accounting.revenue += amount;
+};
+
+Economy.prototype.applyExpense = function (venue, amount, expenseType) {
+  venue.balance -= amount;
+  venue.accounting.expenses += amount;
+  if (expenseType && venue.accounting[expenseType] !== undefined) {
+    venue.accounting[expenseType] += amount;
+  }
+};
+
+Economy.prototype.settleTransaction = function (intent, actorProfile) {
+  var outcome = {
+    ok: false,
+    walletDelta: 0,
+    venue: null,
+    reason: 'no_transaction',
+    price: 0
+  };
+
+  if (!intent) {
+    return outcome;
+  }
+
+  if (intent.type === 'REST') {
+    outcome.ok = true;
+    outcome.reason = 'rested';
+    return outcome;
+  }
+
+  var venueKey = this.resolveVenueForIntent(intent);
+  if (!venueKey || !this.venues[venueKey]) {
+    outcome.reason = 'no_venue';
+    return outcome;
+  }
+
+  var venue = this.venues[venueKey];
+  var quote = intent.quote || this.requestService(intent, actorProfile);
+  outcome.venue = venueKey;
+  outcome.price = quote.price || 0;
+
+  if (!quote.ok) {
+    outcome.reason = quote.reason;
+    return outcome;
+  }
+
+  if (intent.type === 'WORK') {
+    var wage = Math.max(1, quote.price || venue.wage);
+    outcome.ok = true;
+    outcome.walletDelta = wage;
+    outcome.reason = 'paid';
+
+    this.applyExpense(venue, wage, 'payroll');
+    venue.cycleServed += 1;
+    venue.accounting.transactions += 1;
+    return outcome;
+  }
+
+  var price = Math.max(0, quote.price || Math.ceil(venue.dynamicPrice));
+  if (!actorProfile || actorProfile.wallet < price) {
+    venue.cycleFailures += 1;
+    venue.accounting.failedRequests += 1;
+    outcome.reason = 'insufficient_funds';
+    outcome.price = price;
+    return outcome;
+  }
+
+  if (!this.hasInventory(venue, intent)) {
+    venue.cycleFailures += 1;
+    venue.accounting.failedRequests += 1;
+    outcome.reason = 'stock';
+    return outcome;
+  }
+
+  outcome.ok = true;
+  outcome.walletDelta = -price;
+  outcome.reason = 'served';
+  outcome.price = price;
+
+  if (venue.inventoryMax > 0) {
+    venue.inventory = Math.max(0, venue.inventory - 1);
+  }
+
+  this.applyRevenue(venue, price);
+  venue.cycleServed += 1;
+  venue.accounting.transactions += 1;
+
+  return outcome;
+};
+
+Economy.prototype.rebalanceVenue = function (venue) {
+  var shortageRatio = 0;
+  if (venue.inventoryMax > 0) {
+    shortageRatio = 1 - (venue.inventory / venue.inventoryMax);
+  }
+
+  var demandSignal = 0;
+  if (venue.cycleRequests > 0) {
+    demandSignal = (venue.cycleRequests - venue.cycleServed) / venue.cycleRequests;
+  }
+
+  venue.demandPressure = (venue.demandPressure * 0.6) + (Math.max(0, demandSignal) * 0.8);
+
+  if (venue.inventoryMax > 0) {
+    var target = Math.ceil(venue.inventoryMax * 0.65);
+    if (shortageRatio > 0.45) {
+      target = Math.ceil(venue.inventoryMax * 0.85);
+    }
+    var deficit = Math.max(0, target - venue.inventory);
+    if (deficit > 0) {
+      var restockAmount = Math.max(1, Math.min(deficit, Math.ceil(venue.serviceCapacity + venue.demandPressure * 4)));
+      var restockCost = restockAmount * venue.restockUnitCost;
+      venue.inventory = Math.min(venue.inventoryMax, venue.inventory + restockAmount);
+      this.applyExpense(venue, restockCost, 'restock');
+    }
+  }
+
+  var baselinePayroll = Math.ceil(venue.wage * venue.staffCount * 0.35);
+  if (baselinePayroll > 0) {
+    this.applyExpense(venue, baselinePayroll, 'payroll');
+  }
+
+  if (venue.balance < -120 && venue.inventoryMax > 0) {
+    venue.open = false;
+  } else if (venue.balance > -30) {
+    venue.open = true;
+  }
+
+  venue.dynamicPrice = this.computeDynamicPrice(venue);
+  venue.cycleRequests = 0;
+  venue.cycleServed = 0;
+  venue.cycleFailures = 0;
+};
+
+Economy.prototype.rebalance = function () {
+  for (var i = 0; i < this.venueOrder.length; i++) {
+    var key = this.venueOrder[i];
+    this.rebalanceVenue(this.venues[key]);
+  }
+  this.lastRebalanceAt = this.game.time.now;
+};
+
+Economy.prototype.update = function (deltaMs) {
+  this.timeSinceRebalance += deltaMs || 16;
+  if (this.timeSinceRebalance >= this.rebalanceIntervalMs) {
+    this.timeSinceRebalance = 0;
+    this.rebalance();
+  }
+};
+
+Economy.prototype.getVenueSnapshot = function (key) {
+  var venue = this.venues[key];
+  if (!venue) {
+    return null;
+  }
+  return {
+    open: venue.open,
+    inventory: venue.inventory,
+    inventoryMax: venue.inventoryMax,
+    capacity: venue.serviceCapacity,
+    demandPressure: venue.demandPressure,
+    price: Math.ceil(venue.dynamicPrice),
+    accounting: venue.accounting,
+    balance: venue.balance,
+    seats: venue.seats,
+    tellerSlots: venue.tellerSlots
+  };
+};
+
+module.exports = Economy;
+
+},{}]},{},[5]);


### PR DESCRIPTION
### Motivation
- Model city-level business state (bank, bakery, cafe, library, bookstore) so pedestrian intents interact with shared venue capacity, inventory, and finances. 
- Provide dynamic pricing and demand-driven restock/payroll so shortages and closures evolve over time instead of fixed local costs.
- Surface a public API so `Brain.chooseIntent()` and `Brain.resolveIntent()` can quote services and settle transactions against city state.

### Description
- Add new simulation module `js/sim/Economy.js` that defines venues, tracks `inventory`, `serviceCapacity`/`seats`/`tellerSlots`, `balance`, `demandPressure`, `dynamicPrice`, and `accounting` data, and provides `requestService(intent, actorProfile)` and `settleTransaction(intent, actorProfile)` APIs. 
- Implement periodic stabilization via `Economy.rebalance()` and `Economy.update(deltaMs)` which restocks, pays baseline payroll, adjusts `demandPressure` and `dynamicPrice`, and opens/closes venues based on balance. 
- Wire economy into the runtime by instantiating `this.game.economy = new Economy(this.game)` and calling `this.game.economy.update(...)` from the main `Game.update()` loop. 
- Integrate with AI: add `BRAIN.prototype.attachServiceQuote()` to attach quotes from `Economy.requestService()` in `chooseIntent()`, use `Economy.getVenueSnapshot()` in `getNeedCost()`, and call `Economy.settleTransaction()` in `resolveIntent()` so wallet/need outcomes and fatigue reflect actual transaction success/failure. 
- Rebuilt the browser bundle (`static/bundle.js`) so the new module is included.

### Testing
- Ran linting with `npx grunt jshint` which completed with no lint errors. 
- Rebuilt the client bundle with `npx grunt browserify` which produced `static/bundle.js` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dee53c66408327ac43977552cc62c3)