### PR TITLE
Add disruption-aware city damage, recovery economics, and intent rerouting

### DIFF
--- a/js/Game.js
+++ b/js/Game.js
@@ -63,6 +63,7 @@ Uberman.Game.prototype = {
     this.game.back = this.game.add.sprite(this.game.world.centerX - (4267 / 2), this.game.world.height - 2100, 'city_background');
     this.game.fore = this.game.add.sprite(this.game.world.centerX - (4267 / 2), this.game.world.height - 2133, 'city_foreground');
     this.city = new City(this.game, 0,0);
+    this.game.city = this.city;
 
 
   },

--- a/js/prefabs/Brain.js
+++ b/js/prefabs/Brain.js
@@ -345,6 +345,59 @@ BRAIN.prototype.getEconomy = function () {
   return this.game && this.game.economy ? this.game.economy : null;
 };
 
+
+BRAIN.prototype.getCity = function () {
+  return this.game && this.game.city ? this.game.city : null;
+};
+
+BRAIN.prototype.resolveVenueForNeed = function (needName) {
+  var need = this.findNeedByName(needName);
+  if (!need || !need.acts || need.acts.length === 0) {
+    return null;
+  }
+
+  var city = this.getCity();
+  var economy = this.getEconomy();
+
+  for (var i = 0; i < need.acts.length; i++) {
+    var venue = need.acts[i].toLowerCase();
+    var quote = economy ? economy.requestService({ type: 'FULFILL_NEED', door: venue, need: needName }, this.profile) : { ok: true };
+    if (city && !city.isVenueOperational(venue)) {
+      continue;
+    }
+    if (quote && quote.ok) {
+      return { venue: venue, quote: quote };
+    }
+  }
+
+  var primary = need.acts[0].toLowerCase();
+  if (city && city.getVenueAlternatives) {
+    var alternatives = city.getVenueAlternatives(primary, needName);
+    for (var j = 0; j < alternatives.length; j++) {
+      var alternative = alternatives[j];
+      var altQuote = economy ? economy.requestService({ type: 'FULFILL_NEED', door: alternative, need: needName }, this.profile) : { ok: true };
+      if (altQuote && altQuote.ok) {
+        return { venue: alternative, quote: altQuote, rerouted: true };
+      }
+    }
+  }
+
+  return null;
+};
+
+BRAIN.prototype.applyUnmetNeedPressure = function (needName, amount) {
+  var need = this.findNeedByName(needName);
+  if (need) {
+    need.value += amount || 3;
+    need.weight += (amount || 3) * 0.06;
+  }
+  var economy = this.getEconomy();
+  if (economy && economy.registerUnmetNeed) {
+    economy.registerUnmetNeed(needName, 0.35);
+  }
+};
+
+
 BRAIN.prototype.attachServiceQuote = function (intent) {
   if (!intent) {
     return intent;
@@ -569,10 +622,22 @@ BRAIN.prototype.chooseIntent = function () {
     brokeIntent.message = this.describeIntent('WORK', { need: 'MONEY' });
     return this.attachServiceQuote(brokeIntent);
   }
-  var doorKey = topNeed.acts[0].toLowerCase();
-  var intent = this.buildIntent('FULFILL_NEED', doorKey, this.game.world.centerX, topNeed.emotion, topNeed.need);
-  intent = this.attachServiceQuote(intent);
-  intent.message = this.describeIntent('FULFILL_NEED', { need: topNeed.need, emotion: topNeed.emotion, price: intent.quote && intent.quote.price });
+  var route = this.resolveVenueForNeed(topNeed.need);
+  if (!route) {
+    this.applyUnmetNeedPressure(topNeed.need, 4);
+    var fallbackIntent = this.buildIntent('REST', null, this.profile.homeX, 'No safe venue is open; heading home', topNeed.need);
+    fallbackIntent.message = this.describeIntent('REST') + ' Service outage is making needs worse.';
+    return fallbackIntent;
+  }
+
+  var intent = this.buildIntent('FULFILL_NEED', route.venue, this.game.world.centerX, topNeed.emotion, topNeed.need);
+  intent.quote = route.quote;
+  intent.rerouted = !!route.rerouted;
+  if (intent.rerouted) {
+    intent.message = 'Rerouting to ' + route.venue + ' due to disruption. ' + this.describeIntent('FULFILL_NEED', { need: topNeed.need, emotion: topNeed.emotion, price: intent.quote && intent.quote.price });
+  } else {
+    intent.message = this.describeIntent('FULFILL_NEED', { need: topNeed.need, emotion: topNeed.emotion, price: intent.quote && intent.quote.price });
+  }
   return intent;
 };
 
@@ -604,6 +669,7 @@ BRAIN.prototype.resolveIntent = function (intent) {
       this.profile.fatigue = Math.max(0, this.profile.fatigue - 2);
     } else if (need && settlement && !settlement.ok) {
       need.value += 2;
+      this.applyUnmetNeedPressure(intent.need, 2);
     }
     if (!economy && need) {
       var cost = this.getNeedCost(intent.need);

--- a/js/prefabs/City.js
+++ b/js/prefabs/City.js
@@ -4,18 +4,7 @@ CITY = function (game,  x, y) {
   this.game = game;
   this.buildings = this.game.add.group();
   this.game.doors = {};
-  //if (this.game.development === true){
-   this.game.fade = {};
-  //  this.game.back = {};
-   //this.game.fore = {};
-  //}else{
-   // this.game.fade = this.game.add.sprite(this.game.world.centerX - (4267 / 2), this.game.world.height - 2000, 'city_fade');
-
-
-  //}
-
-
-
+  this.game.fade = {};
 
   this.building_data = [
     {"building":1, "ground":37, "floor":25, "top":34, "earth":270, "max_height":40},
@@ -23,36 +12,79 @@ CITY = function (game,  x, y) {
     {"building":3, "ground":0, "floor":136, "top":111, "earth":260, "max_height":20},
     {"building":4, "ground":0, "floor":52, "top":166, "earth":295, "max_height":20}
   ];
-  //this.addRandomBuildings();
+
+  this.serviceTypes = {
+    hydration: { venues: ['cafe'], severity: 0, state: 'stable', recoveryTimerMs: 0, rebuildCost: 0, laborRequired: 0 },
+    food: { venues: ['bakery'], severity: 0, state: 'stable', recoveryTimerMs: 0, rebuildCost: 0, laborRequired: 0 },
+    shelter: { venues: ['library'], severity: 0, state: 'stable', recoveryTimerMs: 0, rebuildCost: 0, laborRequired: 0 },
+    finance: { venues: ['bank'], severity: 0, state: 'stable', recoveryTimerMs: 0, rebuildCost: 0, laborRequired: 0 },
+    culture: { venues: ['bookstore', 'library'], severity: 0, state: 'stable', recoveryTimerMs: 0, rebuildCost: 0, laborRequired: 0 }
+  };
+  this.venueServiceTypeMap = {
+    cafe: 'hydration',
+    bakery: 'food',
+    library: 'shelter',
+    bank: 'finance',
+    bookstore: 'culture'
+  };
+
+  this.damageStates = {
+    destroyed: { capacityMultiplier: 0, inventoryMultiplier: 0, durationMs: 90000, costMultiplier: 1.4, laborMultiplier: 1.8 },
+    degraded: { capacityMultiplier: 0.45, inventoryMultiplier: 0.5, durationMs: 55000, costMultiplier: 1.0, laborMultiplier: 1.2 },
+    recovering: { capacityMultiplier: 0.75, inventoryMultiplier: 0.8, durationMs: 35000, costMultiplier: 0.6, laborMultiplier: 0.6 },
+    stable: { capacityMultiplier: 1, inventoryMultiplier: 1, durationMs: 0, costMultiplier: 0, laborMultiplier: 0 }
+  };
+
+  this.damageModel = {
+    instability: 0,
+    instabilityDecayPerSecond: 0.035,
+    lastUpdateAt: this.game.time.now,
+    venueStatus: {},
+    debugLines: []
+  };
+
   this.addOrderedBuildings();
   this.addBank();
   this.addLibrary();
   this.addBakery();
   this.addCafe();
   this.addBookstore();
-
-  //console.log(this.buildings);
   this.addBuildingsToGame();
 
-
+  this.initializeDamageModel();
 };
 
 CITY.prototype = Object.create(Phaser.Sprite.prototype);
 CITY.prototype.constructor = CITY;
 
-CITY.prototype.shuffleGroupChildren = function (array) {
-
-    for (var i = array.length - 1; i > 0; i--) {
-      var j = Math.floor(Math.random() * (i + 1));
-      var temp = array[i];
-      array[i] = array[j];
-      array[j] = temp;
-    }
-
-
-    return array;
-
+CITY.prototype.initializeDamageModel = function () {
+  var venues = ['bank', 'bakery', 'cafe', 'library', 'bookstore'];
+  for (var i = 0; i < venues.length; i++) {
+    this.damageModel.venueStatus[venues[i]] = {
+      venue: venues[i],
+      state: 'stable',
+      severity: 0,
+      recoveryTimerMs: 0,
+      rebuildCost: 0,
+      laborRequired: 0,
+      unavailable: false,
+      capacityModifier: 1,
+      inventoryModifier: 1,
+      source: null
+    };
+  }
 };
+
+CITY.prototype.shuffleGroupChildren = function (array) {
+  for (var i = array.length - 1; i > 0; i--) {
+    var j = Math.floor(Math.random() * (i + 1));
+    var temp = array[i];
+    array[i] = array[j];
+    array[j] = temp;
+  }
+  return array;
+};
+
 CITY.prototype.addBuildingsToGame = function () {
   var counter = 0;
   var startX = 200;
@@ -61,147 +93,381 @@ CITY.prototype.addBuildingsToGame = function () {
   var building_data = this.building_data;
   this.buildings.children = this.shuffleGroupChildren(this.buildings.children);
 
-  for(var bcount = 0;bcount<this.buildings.children.length;bcount++){
+  for (var bcount = 0; bcount < this.buildings.children.length; bcount++) {
     var sprite = this.buildings.children[bcount];
     var type = sprite instanceof Phaser.Group;
 
-    if(type === false){
+    if (type === false) {
       sprite.exists = true;
       sprite.x = startX;
-      this.game.doors[sprite.key] = this.game.add.sprite(sprite.centerX, sprite.y+sprite.height-40, 'door');
-      this.game.doors[sprite.key].anchor.setTo(0.5,0.5);
+      this.game.doors[sprite.key] = this.game.add.sprite(sprite.centerX, sprite.y + sprite.height - 40, 'door');
+      this.game.doors[sprite.key].anchor.setTo(0.5, 0.5);
 
-      //var building = sprite.game.add.existing(sprite);
       buildingWidth = sprite.width;
       counter += 1;
-    }else{
+    } else {
 
-      var nextY = sprite.game.world.height-270;
+      var nextY = sprite.game.world.height - 270;
       var heightCount = 0;
 
-      for(var gcount = 0;gcount<sprite.children.length;gcount++){
+      for (var gcount = 0; gcount < sprite.children.length; gcount++) {
         var deepSprite = sprite.children[gcount];
 
-        var data = deepSprite.key.split("_");
+        var data = deepSprite.key.split('_');
         var level = data[0];
         var level_data;
         var building_num = data[1];
         deepSprite.exists = true;
         deepSprite.x = startX;
 
+        for (var i = 0; i < building_data.length; i++) {
+          var building_level = building_data[i];
 
-          for(var i=0;i<building_data.length;i++){
-            var building_level = building_data[i];
+          if (building_level.building === parseInt(building_num)) {
+            level_data = building_level;
+            break;
 
-            if(building_level.building === parseInt(building_num)){
-              level_data = building_level;
-              break;
-
-            }
           }
+        }
 
-        switch(level){
-          case "ground":
+        switch (level) {
+          case 'ground':
             nextY = sprite.game.world.height - (level_data.earth + level_data.ground);
             break;
-          case "floor":
+          case 'floor':
             nextY = (sprite.game.world.height - (level_data.earth + level_data.ground + (level_data.floor * heightCount)));
             break;
-          case "top":
-            nextY = (sprite.game.world.height - (level_data.earth + level_data.ground + (level_data.floor * (heightCount-1)))-(level_data.top));
+          case 'top':
+            nextY = (sprite.game.world.height - (level_data.earth + level_data.ground + (level_data.floor * (heightCount - 1))) - (level_data.top));
             break;
         }
 
         deepSprite.y = nextY;
 
         buildingWidth = deepSprite.width;
-        counter+=1;
-        heightCount+=1;
+        counter += 1;
+        heightCount += 1;
       }
-
-
     }
 
-    startX = startX + buildingWidth+sprite.game.rnd.integerInRange(0, 15);
+    startX = startX + buildingWidth + sprite.game.rnd.integerInRange(0, 15);
   }
 };
 
-
-CITY.prototype.addLibrary = function() {
-  this.buildings.create(0, this.game.world.height - 440, "library", 0,false);
+CITY.prototype.addLibrary = function () {
+  this.buildings.create(0, this.game.world.height - 440, 'library', 0, false);
 };
-CITY.prototype.addBakery = function(){
-  this.buildings.create(0, this.game.world.height - 495, "bakery", 0,false);
-
-};
-CITY.prototype.addCafe = function(){
-  this.buildings.create(0, this.game.world.height - 495, "cafe", 0,false);
+CITY.prototype.addBakery = function () {
+  this.buildings.create(0, this.game.world.height - 495, 'bakery', 0, false);
 
 };
-CITY.prototype.addBookstore = function(){
-  this.buildings.create(0, this.game.world.height - 495, "bookstore", 0,false);
+CITY.prototype.addCafe = function () {
+  this.buildings.create(0, this.game.world.height - 495, 'cafe', 0, false);
+
+};
+CITY.prototype.addBookstore = function () {
+  this.buildings.create(0, this.game.world.height - 495, 'bookstore', 0, false);
 
 };
 
-CITY.prototype.addBank = function() {
-  this.buildings.create(0, this.game.world.height - 488, "bank", 0,false);
+CITY.prototype.addBank = function () {
+  this.buildings.create(0, this.game.world.height - 488, 'bank', 0, false);
 };
 
-CITY.prototype.addRandomBuildings = function() {
+CITY.prototype.addRandomBuildings = function () {
   for (var i = 0; i < this.game.rnd.integerInRange(10, 100); i++) {
     var building = this.building_data[this.game.rnd.integerInRange(0, this.building_data.length - 1)];
-    var created_building = this.createBuilding(
-      ["ground_" + building.building, building.ground],
-      ["floor_" + building.building, building.floor],
-      ["top_" + building.building, building.top],
+    this.createBuilding(
+      ['ground_' + building.building, building.ground],
+      ['floor_' + building.building, building.floor],
+      ['top_' + building.building, building.top],
       building.earth, building.max_height);
   }
 };
 
-CITY.prototype.addOrderedBuildings = function() {
-  var modifier = 15;
+CITY.prototype.addOrderedBuildings = function () {
   for (var i = 0; i < this.building_data.length; i++) {
-
     var building = this.building_data[i];
 
     var building_added = this.createBuilding(
-      ["ground_" + building.building, building.ground],
-      ["floor_" + building.building, building.floor],
-      ["top_" + building.building, building.top], building.max_height);
-    //console.log(building_added);
+      ['ground_' + building.building, building.ground],
+      ['floor_' + building.building, building.floor],
+      ['top_' + building.building, building.top], building.max_height);
     this.buildings.add(building_added);
   }
 };
 
-
-
-
-
-
-
-CITY.prototype.createBuilding = function(ground, floor, top, max_height) {
-
+CITY.prototype.createBuilding = function (ground, floor, top, max_height) {
   var height = this.game.rnd.integerInRange(10, max_height);
-
   var floored_building = this.game.add.group();
 
-  floored_building.create(0, 0, ground[0], 0,false);
+  floored_building.create(0, 0, ground[0], 0, false);
 
-  for (var i = 0; i <height; i++) {
-
-    floored_building.create(0, 0, floor[0], 0,false);
+  for (var i = 0; i < height; i++) {
+    floored_building.create(0, 0, floor[0], 0, false);
   }
 
-  floored_building.create(0, 0, top[0], 0,false);
+  floored_building.create(0, 0, top[0], 0, false);
 
   return floored_building;
 };
 
+CITY.prototype.getRecoveryProfile = function (state, severity) {
+  var template = this.damageStates[state] || this.damageStates.degraded;
+  var normalizedSeverity = Math.max(0.1, Math.min(1, severity || 0.5));
+  return {
+    state: state,
+    capacityModifier: template.capacityMultiplier,
+    inventoryModifier: template.inventoryMultiplier,
+    recoveryTimerMs: Math.ceil(template.durationMs * (0.7 + normalizedSeverity)),
+    rebuildCost: Math.ceil((140 + normalizedSeverity * 420) * template.costMultiplier),
+    laborRequired: Math.ceil((35 + normalizedSeverity * 130) * template.laborMultiplier)
+  };
+};
 
-CITY.prototype.animateDamage = function() {
+CITY.prototype.markVenueDamage = function (venue, state, options) {
+  var venueState = this.damageModel.venueStatus[venue];
+  if (!venueState) {
+    return null;
+  }
+
+  var damageState = this.damageStates[state] ? state : 'degraded';
+  var severity = options && options.severity !== undefined ? options.severity : 0.5;
+  var profile = this.getRecoveryProfile(damageState, severity);
+
+  venueState.state = damageState;
+  venueState.severity = severity;
+  venueState.recoveryTimerMs = profile.recoveryTimerMs;
+  venueState.rebuildCost = profile.rebuildCost;
+  venueState.laborRequired = profile.laborRequired;
+  venueState.unavailable = damageState === 'destroyed';
+  venueState.capacityModifier = profile.capacityModifier;
+  venueState.inventoryModifier = profile.inventoryModifier;
+  venueState.source = options && options.source ? options.source : 'incident';
+
+  this.damageModel.instability = Math.min(1.5, this.damageModel.instability + (0.2 + severity * 0.55));
+
+  return venueState;
+};
+
+CITY.prototype.markServiceDamage = function (serviceType, state, options) {
+  var service = this.serviceTypes[serviceType];
+  if (!service) {
+    return;
+  }
+  service.state = state;
+  service.severity = Math.max(service.severity || 0, options && options.severity !== undefined ? options.severity : 0.5);
+
+  for (var i = 0; i < service.venues.length; i++) {
+    this.markVenueDamage(service.venues[i], state, options);
+  }
+};
+
+CITY.prototype.markVenueUnavailable = function (venue, source) {
+  return this.markVenueDamage(venue, 'destroyed', { severity: 0.85, source: source || 'battle' });
+};
+
+CITY.prototype.markVenueReducedCapacity = function (venue, severity, source) {
+  return this.markVenueDamage(venue, 'degraded', { severity: severity || 0.45, source: source || 'catastrophe' });
+};
+
+CITY.prototype.triggerCatastrophe = function (options) {
+  var intensity = options && options.intensity !== undefined ? options.intensity : this.game.rnd.frac();
+  var allVenues = Object.keys(this.damageModel.venueStatus);
+  var hitCount = Math.max(1, Math.min(allVenues.length, Math.ceil(1 + intensity * 3)));
+  var impacted = [];
+
+  for (var i = 0; i < hitCount; i++) {
+    var venue = allVenues[this.game.rnd.integerInRange(0, allVenues.length - 1)];
+    if (impacted.indexOf(venue) !== -1) {
+      continue;
+    }
+    impacted.push(venue);
+    if (this.game.rnd.frac() < 0.35 + intensity * 0.4) {
+      this.markVenueUnavailable(venue, 'catastrophe');
+    } else {
+      this.markVenueReducedCapacity(venue, 0.35 + intensity * 0.55, 'catastrophe');
+    }
+  }
+
+  this.damageModel.instability = Math.min(1.8, this.damageModel.instability + 0.25 + intensity * 0.8);
+};
+
+CITY.prototype.getVenueStatus = function (venue) {
+  return this.damageModel.venueStatus[venue] || null;
+};
+
+CITY.prototype.isVenueOperational = function (venue) {
+  var status = this.getVenueStatus(venue);
+  return !status || status.state !== 'destroyed';
+};
+
+CITY.prototype.getVenueAlternatives = function (venue, needName) {
+  var economy = this.game && this.game.economy;
+  var serviceType = this.venueServiceTypeMap[venue] || null;
+
+  if (!serviceType && economy && economy.needVenueMap && needName) {
+    serviceType = this.venueServiceTypeMap[economy.needVenueMap[needName]];
+  }
+
+  if (!serviceType || !this.serviceTypes[serviceType]) {
+    return [];
+  }
+
+  var possibilities = this.serviceTypes[serviceType].venues;
+  var alternatives = [];
+
+  for (var i = 0; i < possibilities.length; i++) {
+    var candidate = possibilities[i];
+    if (candidate === venue) {
+      continue;
+    }
+    var damage = this.getVenueStatus(candidate);
+    if (damage && damage.state === 'destroyed') {
+      continue;
+    }
+    if (economy && economy.isVenueClosedForDisruption && economy.isVenueClosedForDisruption(candidate)) {
+      continue;
+    }
+    alternatives.push(candidate);
+  }
+
+  return alternatives;
+};
+
+CITY.prototype.advanceVenueRecovery = function (venueState, deltaMs) {
+  if (venueState.state === 'stable') {
+    return;
+  }
+
+  venueState.recoveryTimerMs = Math.max(0, venueState.recoveryTimerMs - deltaMs);
+  if (venueState.recoveryTimerMs > 0) {
+    return;
+  }
+
+  if (venueState.state === 'destroyed') {
+    var recovering = this.getRecoveryProfile('recovering', venueState.severity || 0.5);
+    venueState.state = 'recovering';
+    venueState.unavailable = false;
+    venueState.capacityModifier = recovering.capacityModifier;
+    venueState.inventoryModifier = recovering.inventoryModifier;
+    venueState.recoveryTimerMs = recovering.recoveryTimerMs;
+    venueState.rebuildCost = Math.ceil(venueState.rebuildCost * 0.55);
+    venueState.laborRequired = Math.ceil(venueState.laborRequired * 0.5);
+    return;
+  }
+
+  if (venueState.state === 'degraded') {
+    var recoveringProfile = this.getRecoveryProfile('recovering', venueState.severity || 0.45);
+    venueState.state = 'recovering';
+    venueState.capacityModifier = recoveringProfile.capacityModifier;
+    venueState.inventoryModifier = recoveringProfile.inventoryModifier;
+    venueState.recoveryTimerMs = recoveringProfile.recoveryTimerMs;
+    venueState.rebuildCost = Math.ceil(venueState.rebuildCost * 0.45);
+    venueState.laborRequired = Math.ceil(venueState.laborRequired * 0.55);
+    return;
+  }
+
+  venueState.state = 'stable';
+  venueState.severity = 0;
+  venueState.rebuildCost = 0;
+  venueState.laborRequired = 0;
+  venueState.unavailable = false;
+  venueState.capacityModifier = 1;
+  venueState.inventoryModifier = 1;
+  venueState.recoveryTimerMs = 0;
+};
+
+CITY.prototype.applyRecoveryEconomics = function (venueState, deltaMs) {
+  var economy = this.game && this.game.economy;
+  if (!economy || venueState.state === 'stable') {
+    return;
+  }
+  var venue = economy.venues[venueState.venue];
+  if (!venue) {
+    return;
+  }
+
+  var repairBudgetPerSecond = Math.max(2, Math.floor(Math.max(0, venue.balance + 80) * 0.04));
+  var laborBudgetPerSecond = Math.max(1, Math.floor(venue.staffCount * venue.wage * 0.08));
+
+  var dtSeconds = Math.max(0.016, deltaMs / 1000);
+  var repairSpend = Math.min(venueState.rebuildCost, Math.ceil(repairBudgetPerSecond * dtSeconds));
+  var laborSpend = Math.min(venueState.laborRequired, Math.ceil(laborBudgetPerSecond * dtSeconds));
+
+  venueState.rebuildCost = Math.max(0, venueState.rebuildCost - repairSpend);
+  venueState.laborRequired = Math.max(0, venueState.laborRequired - laborSpend);
+
+  if (repairSpend > 0) {
+    venue.balance = Math.max(-450, venue.balance - repairSpend);
+  }
+  if (laborSpend > 0) {
+    venue.balance = Math.max(-450, venue.balance - Math.ceil(laborSpend * 0.25));
+  }
+
+  if (venueState.rebuildCost === 0 && venueState.laborRequired === 0) {
+    venueState.recoveryTimerMs = Math.min(venueState.recoveryTimerMs, Math.ceil(2200 + (1 - Math.max(0, venue.balance) / 900) * 3000));
+  }
+};
+
+CITY.prototype.pushDisruptionToEconomy = function () {
+  var economy = this.game && this.game.economy;
+  if (!economy || !economy.applyDisruptionSnapshot) {
+    return;
+  }
+  economy.applyDisruptionSnapshot(this.damageModel.venueStatus, this.damageModel.instability);
+};
+
+CITY.prototype.updateDebugLines = function () {
+  var keys = Object.keys(this.damageModel.venueStatus);
+  var lines = ['CITY INSTABILITY ' + this.damageModel.instability.toFixed(2)];
+
+  for (var i = 0; i < keys.length; i++) {
+    var status = this.damageModel.venueStatus[keys[i]];
+    var timerSeconds = Math.ceil((status.recoveryTimerMs || 0) / 1000);
+    lines.push(
+      status.venue.toUpperCase() + ': ' + status.state +
+      ' cap x' + status.capacityModifier.toFixed(2) +
+      ' t-' + timerSeconds + 's' +
+      (status.rebuildCost > 0 ? ' $' + status.rebuildCost : '') +
+      (status.laborRequired > 0 ? ' L' + status.laborRequired : '')
+    );
+  }
+
+  this.damageModel.debugLines = lines;
+};
+
+CITY.prototype.getDebugDamageLines = function () {
+  return this.damageModel.debugLines || [];
+};
+
+CITY.prototype.animateDamage = function () {
 
 };
-CITY.prototype.update = function() {
+
+CITY.prototype.updateDamageModel = function (deltaMs) {
+  var dt = deltaMs || Math.max(16, this.game.time.now - this.damageModel.lastUpdateAt);
+  this.damageModel.lastUpdateAt = this.game.time.now;
+
+  if (this.game.rnd.frac() < (0.00002 + Math.max(0, this.damageModel.instability) * 0.0003)) {
+    this.triggerCatastrophe({ intensity: Math.min(1, 0.25 + this.damageModel.instability) });
+  }
+
+  var keys = Object.keys(this.damageModel.venueStatus);
+  for (var i = 0; i < keys.length; i++) {
+    var venueState = this.damageModel.venueStatus[keys[i]];
+    this.applyRecoveryEconomics(venueState, dt);
+    this.advanceVenueRecovery(venueState, dt);
+  }
+
+  this.damageModel.instability = Math.max(0, this.damageModel.instability - this.damageModel.instabilityDecayPerSecond * (dt / 1000));
+
+  this.pushDisruptionToEconomy();
+  this.updateDebugLines();
+};
+
+CITY.prototype.update = function () {
+  var deltaMs = this.game.time.elapsedMS || 16;
 
   this.game.back.x -= this.game.player.body.velocity.x * (0.001);
   this.game.fade.x -= this.game.player.body.velocity.x * (0.0005);
@@ -209,6 +475,7 @@ CITY.prototype.update = function() {
   this.game.back.y -= this.game.player.body.velocity.y * (0.001);
   this.game.fade.y -= this.game.player.body.velocity.y * (0.0005);
 
+  this.updateDamageModel(deltaMs);
 };
 
 module.exports = CITY;

--- a/js/prefabs/Hud.js
+++ b/js/prefabs/Hud.js
@@ -41,6 +41,11 @@ HUD = function (game,  x, y) {
   // just a property we can tween so the bar has a progress to show
   this.barProgress = 128;
 
+  this.cityDebugText = this.game.add.bitmapText(0, 0, 'smallfont', '', 14);
+  this.cityDebugText.fixedToCamera = true;
+  this.cityDebugText.cameraOffset.setTo(18, 140);
+  this.cityDebugText.maxWidth = 420;
+  this.cityDebugText.align = 'left';
 
 };
 
@@ -104,6 +109,12 @@ HUD.prototype.update = function() {
 
   // important - without this line, the context will never be updated on the GPU when using webGL
   this.bar.dirty = true;
+
+  if (this.game.city && this.game.city.getDebugDamageLines) {
+    var damageLines = this.game.city.getDebugDamageLines();
+    this.cityDebugText.text = damageLines.join('\n');
+  }
+
   this.animateDamage();
 };
 

--- a/js/sim/Economy.js
+++ b/js/sim/Economy.js
@@ -3,6 +3,8 @@ var Economy = function (game) {
   this.rebalanceIntervalMs = 12000;
   this.timeSinceRebalance = 0;
   this.lastRebalanceAt = 0;
+  this.cityInstability = 0;
+  this.disruption = {};
 
   this.venueOrder = ['bank', 'bakery', 'cafe', 'library', 'bookstore'];
   this.needVenueMap = {
@@ -109,6 +111,33 @@ Economy.prototype.createVenue = function (key, options) {
   return venue;
 };
 
+
+Economy.prototype.applyDisruptionSnapshot = function (venueStatus, instability) {
+  this.disruption = venueStatus || {};
+  this.cityInstability = Math.max(0, instability || 0);
+};
+
+Economy.prototype.getDisruptionForVenue = function (venueKey) {
+  return this.disruption && this.disruption[venueKey] ? this.disruption[venueKey] : null;
+};
+
+Economy.prototype.isVenueClosedForDisruption = function (venueKey) {
+  var disruption = this.getDisruptionForVenue(venueKey);
+  return !!(disruption && disruption.state === 'destroyed');
+};
+
+Economy.prototype.getOperationalCapacity = function (venue) {
+  var disruption = this.getDisruptionForVenue(venue.key);
+  var multiplier = disruption && disruption.capacityModifier !== undefined ? disruption.capacityModifier : 1;
+  return Math.max(0, Math.floor(venue.serviceCapacity * multiplier));
+};
+
+Economy.prototype.getOperationalInventory = function (venue) {
+  var disruption = this.getDisruptionForVenue(venue.key);
+  var multiplier = disruption && disruption.inventoryModifier !== undefined ? disruption.inventoryModifier : 1;
+  return Math.max(0, Math.floor(venue.inventory * multiplier));
+};
+
 Economy.prototype.resolveVenueForIntent = function (intent) {
   if (!intent) {
     return null;
@@ -129,14 +158,15 @@ Economy.prototype.computeDynamicPrice = function (venue) {
     shortageRatio = Math.max(0, Math.min(1, shortageRatio));
   }
   var pressure = Math.max(0, Math.min(2, venue.demandPressure));
-  var multiplier = 1 + (shortageRatio * 0.8) + (pressure * 0.45);
+  var disruptionTax = this.cityInstability * 0.35;
+  var multiplier = 1 + (shortageRatio * 0.8) + (pressure * 0.45) + disruptionTax;
   var minPrice = venue.basePrice * 0.6;
   var maxPrice = venue.basePrice * 2.5;
   return Math.max(minPrice, Math.min(maxPrice, venue.basePrice * multiplier));
 };
 
 Economy.prototype.hasCapacity = function (venue) {
-  return venue.cycleRequests <= venue.serviceCapacity;
+  return venue.cycleRequests <= this.getOperationalCapacity(venue);
 };
 
 Economy.prototype.hasInventory = function (venue, intent) {
@@ -146,7 +176,7 @@ Economy.prototype.hasInventory = function (venue, intent) {
   if (venue.inventoryMax <= 0) {
     return true;
   }
-  return venue.inventory > 0;
+  return this.getOperationalInventory(venue) > 0;
 };
 
 Economy.prototype.requestService = function (intent, actorProfile) {
@@ -169,12 +199,13 @@ Economy.prototype.requestService = function (intent, actorProfile) {
   venue.cycleRequests += 1;
   venue.dynamicPrice = this.computeDynamicPrice(venue);
 
-  quote.capacity = Math.max(0, venue.serviceCapacity - venue.cycleRequests);
-  quote.inventory = venue.inventory;
-  quote.open = venue.open;
+  quote.capacity = Math.max(0, this.getOperationalCapacity(venue) - venue.cycleRequests);
+  quote.inventory = this.getOperationalInventory(venue);
+  var disruption = this.getDisruptionForVenue(venueKey);
+  quote.open = venue.open && !(disruption && disruption.state === 'destroyed');
   quote.price = Math.ceil(venue.dynamicPrice);
 
-  if (!venue.open) {
+  if (!quote.open) {
     venue.cycleFailures += 1;
     venue.accounting.failedRequests += 1;
     quote.reason = 'closed';
@@ -215,6 +246,15 @@ Economy.prototype.applyExpense = function (venue, amount, expenseType) {
   if (expenseType && venue.accounting[expenseType] !== undefined) {
     venue.accounting[expenseType] += amount;
   }
+};
+
+Economy.prototype.registerUnmetNeed = function (needName, pressure) {
+  var venueKey = this.needVenueMap[needName];
+  if (!venueKey || !this.venues[venueKey]) {
+    return;
+  }
+  var venue = this.venues[venueKey];
+  venue.demandPressure = Math.min(2.5, venue.demandPressure + (pressure || 0.25));
 };
 
 Economy.prototype.settleTransaction = function (intent, actorProfile) {
@@ -328,11 +368,19 @@ Economy.prototype.rebalanceVenue = function (venue) {
     this.applyExpense(venue, baselinePayroll, 'payroll');
   }
 
+  var disruption = this.getDisruptionForVenue(venue.key);
+  var disruptionClosed = disruption && disruption.state === 'destroyed';
+
   if (venue.balance < -120 && venue.inventoryMax > 0) {
     venue.open = false;
-  } else if (venue.balance > -30) {
+  } else if (venue.balance > -30 && !disruptionClosed) {
     venue.open = true;
   }
+
+  var shortageStress = Math.max(0, shortageRatio - 0.2) * 1.8;
+  var disruptionStress = this.cityInstability * 0.5 + (disruption && disruption.state !== 'stable' ? 0.25 : 0);
+  var wageTarget = venue.wage * (1 + shortageStress + disruptionStress);
+  venue.wage = Math.max(5, Math.min(45, Math.floor((venue.wage * 0.75) + (wageTarget * 0.25))));
 
   venue.dynamicPrice = this.computeDynamicPrice(venue);
   venue.cycleRequests = 0;
@@ -371,7 +419,11 @@ Economy.prototype.getVenueSnapshot = function (key) {
     accounting: venue.accounting,
     balance: venue.balance,
     seats: venue.seats,
-    tellerSlots: venue.tellerSlots
+    tellerSlots: venue.tellerSlots,
+    operationalCapacity: this.getOperationalCapacity(venue),
+    operationalInventory: this.getOperationalInventory(venue),
+    instability: this.cityInstability,
+    disruption: this.getDisruptionForVenue(key)
   };
 };
 


### PR DESCRIPTION
### Motivation

- Provide a per-venue and per-service damage model so battles/catastrophes can make venues `destroyed`, `degraded`, `recovering`, or `stable` and affect gameplay.
- Ensure recovery depends on local funds and labor so rebuilds consume economic resources and instability temporarily shifts equilibrium.
- Route pedestrian AI around outages and surface disruption state to the HUD so emergent shortages, price/wage shifts, rerouting and unmet-need pressure are visible and actionable.

### Description

- Added a city damage/recovery subsystem in `js/prefabs/City.js` including service-type mappings, `damageStates`, per-venue `damageModel`, recovery profiles, methods `markVenueDamage`, `markServiceDamage`, `markVenueUnavailable`, `markVenueReducedCapacity`, `triggerCatastrophe`, `advanceVenueRecovery`, `applyRecoveryEconomics`, and `pushDisruptionToEconomy` that stage recovery and consume rebuild cost/labor over time.
- Integrated disruption into the economy in `js/sim/Economy.js` with `applyDisruptionSnapshot`, `getDisruptionForVenue`, `getOperationalCapacity`, `getOperationalInventory`, a `cityInstability` factor that increases prices (`computeDynamicPrice`), reduces operational capacity/inventory for quotes, and influences wage adjustments and venue openness during rebalances.
- Updated agent planning in `js/prefabs/Brain.js` by adding `getCity`, `resolveVenueForNeed`, and `applyUnmetNeedPressure`, and changed `chooseIntent()` to reroute to alternatives when primary venues are disrupted and increase unmet-need pressure / fallback when no viable route exists.
- UI and wiring changes: added `game.city` in `js/Game.js`, and HUD debug output in `js/prefabs/Hud.js` that shows `CITY INSTABILITY` and per-venue outage/recovery lines via `City.getDebugDamageLines()`.

### Testing

- Ran linting with `npx grunt jshint`, which passed: "15 files lint free.".
- Performed a quick module load check with `node -e "require('./js/sim/Economy.js');require('./js/prefabs/City.js');require('./js/prefabs/Brain.js');"` which failed due to `ReferenceError: Phaser is not defined` in a Node (non-browser) environment, which is expected because `Phaser` is provided at runtime in the browser.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dee9f57a088327ba3ddf6df0dccdc8)