### PR TITLE
Make Brain need weighting deterministic and data-driven

### DIFF
--- a/js/data/brainNeedBalancing.json
+++ b/js/data/brainNeedBalancing.json
@@ -1,0 +1,54 @@
+{
+  "tierOrder": [
+    "physiological",
+    "safety",
+    "social",
+    "esteem",
+    "selfActualization"
+  ],
+  "tierUrgency": {
+    "physiological": 1.8,
+    "safety": 1.4,
+    "social": 1.15,
+    "esteem": 1.0,
+    "selfActualization": 0.85
+  },
+  "clamp": {
+    "min": 0,
+    "max": 100
+  },
+  "weightCurve": {
+    "baseline": 0.25,
+    "deficitExponent": 1.35
+  },
+  "defaultCurve": {
+    "decayPerTick": 0.08,
+    "passiveRecoveryPerTick": 0.0,
+    "recoveryOnResolve": 55
+  },
+  "needCurves": {
+    "WATER": { "decayPerTick": 0.18, "passiveRecoveryPerTick": 0.01, "recoveryOnResolve": 82 },
+    "FOOD": { "decayPerTick": 0.15, "passiveRecoveryPerTick": 0.01, "recoveryOnResolve": 78 },
+    "SECURITY": { "decayPerTick": 0.1, "passiveRecoveryPerTick": 0.01, "recoveryOnResolve": 60 },
+    "MONEY": { "decayPerTick": 0.12, "passiveRecoveryPerTick": 0.0, "recoveryOnResolve": 70 },
+    "WARMTH": { "decayPerTick": 0.11, "passiveRecoveryPerTick": 0.01, "recoveryOnResolve": 62 },
+    "FRIENDSHIP": { "decayPerTick": 0.09, "passiveRecoveryPerTick": 0.01, "recoveryOnResolve": 58 },
+    "INTIMACY": { "decayPerTick": 0.08, "passiveRecoveryPerTick": 0.01, "recoveryOnResolve": 56 },
+    "FAMILY": { "decayPerTick": 0.08, "passiveRecoveryPerTick": 0.01, "recoveryOnResolve": 56 },
+    "CONFIDENCE": { "decayPerTick": 0.07, "passiveRecoveryPerTick": 0.01, "recoveryOnResolve": 54 },
+    "ART": { "decayPerTick": 0.06, "passiveRecoveryPerTick": 0.01, "recoveryOnResolve": 52 },
+    "EDUCATION": { "decayPerTick": 0.06, "passiveRecoveryPerTick": 0.01, "recoveryOnResolve": 52 }
+  },
+  "gating": {
+    "lowerTierDeficitThreshold": 0.35,
+    "unstableLowerTierMultiplier": 0.55,
+    "stableLowerTierBoost": 0.65
+  },
+  "cooldown": {
+    "lookbackTicks": 240,
+    "graceTicks": 45,
+    "penaltyPerRepeat": 0.35,
+    "recentVisitBonusCount": 1,
+    "historyLimit": 40
+  }
+}

--- a/js/prefabs/Brain.js
+++ b/js/prefabs/Brain.js
@@ -1,6 +1,8 @@
+var NEED_BALANCING = require('../data/brainNeedBalancing.json');
 
 BRAIN = function (game) {
   this.game = game;
+  this.needBalancing = NEED_BALANCING;
   this.profile = this.generateProfile();
   this.thoughts = {
     "needs": [
@@ -239,6 +241,9 @@ BRAIN = function (game) {
   };
 
   this.profile = this.generateProfile();
+  this.profile.simTick = 0;
+  this.profile.venueHistory = [];
+  this.initializeNeedRuntimeData();
 
 
 };
@@ -395,8 +400,7 @@ BRAIN.prototype.resolveVenueForNeed = function (needName) {
 BRAIN.prototype.applyUnmetNeedPressure = function (needName, amount) {
   var need = this.findNeedByName(needName);
   if (need) {
-    need.value += amount || 3;
-    need.weight += (amount || 3) * 0.06;
+    need.value = this.clampNeedValue(need.value + (amount || 3));
   }
   var economy = this.getEconomy();
   if (economy && economy.registerUnmetNeed) {
@@ -456,8 +460,7 @@ BRAIN.prototype.applyFailureState = function (needName, pressure, emotion) {
     return;
   }
   var amount = pressure || 2;
-  need.value += amount;
-  need.weight += amount * 0.08;
+  need.value = this.clampNeedValue(need.value + amount);
   if (emotion) {
     need.emotion = emotion;
   }
@@ -684,30 +687,110 @@ BRAIN.prototype.describeIntent = function (type, data) {
   return data && data.emotion ? data.emotion : 'On the move';
 };
 
+BRAIN.prototype.initializeNeedRuntimeData = function () {
+  for (var i = 0; i < this.thoughts.needs.length; i++) {
+    var tierName = this.getTierName(i);
+    var tierNeeds = this.thoughts.needs[i].maslow;
+    for (var j = 0; j < tierNeeds.length; j++) {
+      tierNeeds[j].tier = tierName;
+      tierNeeds[j].lastServedVenue = null;
+      tierNeeds[j].lastServedTick = -99999;
+    }
+  }
+};
+
+BRAIN.prototype.getTierName = function (tierIndex) {
+  var order = this.needBalancing.tierOrder;
+  return order[tierIndex] || order[order.length - 1];
+};
+
+BRAIN.prototype.clampNeedValue = function (value) {
+  var clamp = this.needBalancing.clamp;
+  return Math.max(clamp.min, Math.min(clamp.max, value));
+};
+
+BRAIN.prototype.getNeedCurve = function (needName) {
+  var curves = this.needBalancing.needCurves || {};
+  return curves[needName] || this.needBalancing.defaultCurve;
+};
+
+BRAIN.prototype.getTierGateMultiplier = function (tierIndex, lowerTierStable, normalizedDeficit) {
+  var gating = this.needBalancing.gating;
+  if (tierIndex === 0) {
+    return 1;
+  }
+  if (lowerTierStable) {
+    return 1 + gating.stableLowerTierBoost * normalizedDeficit;
+  }
+  return gating.unstableLowerTierMultiplier;
+};
+
+BRAIN.prototype.getNeedCooldownPenalty = function (need) {
+  if (!need) {
+    return 0;
+  }
+  var cooldown = this.needBalancing.cooldown;
+  var history = this.profile.venueHistory || [];
+  if (!need.lastServedVenue || history.length === 0) {
+    return 0;
+  }
+
+  var repeatCount = 0;
+  for (var i = history.length - 1; i >= 0; i--) {
+    if ((this.profile.simTick - history[i].tick) > cooldown.lookbackTicks) {
+      break;
+    }
+    if (history[i].venue === need.lastServedVenue) {
+      repeatCount += 1;
+    }
+  }
+
+  var sinceLastServed = this.profile.simTick - (need.lastServedTick || 0);
+  if (sinceLastServed <= cooldown.graceTicks) {
+    repeatCount += cooldown.recentVisitBonusCount;
+  }
+  return repeatCount * cooldown.penaltyPerRepeat;
+};
+
 BRAIN.prototype.getWeight= function (x,y,i) {
-  return ( (y*(i+1)-y*(i))/(x*(i+1)-x*(i)) - (y*(i)-y*(i-1))/(x*(i)-x*(i-1))/(x*(i+1)-x*(i-1)));
+  var clampedValue = this.clampNeedValue(y);
+  var tierName = this.getTierName(i);
+  var tierUrgency = this.needBalancing.tierUrgency[tierName] || 1;
+  var normalizedDeficit = (this.needBalancing.clamp.max - clampedValue) / this.needBalancing.clamp.max;
+  normalizedDeficit = Math.max(0, Math.min(1, normalizedDeficit));
+  var deficitCurve = Math.pow(normalizedDeficit, this.needBalancing.weightCurve.deficitExponent);
+  return x * tierUrgency * (this.needBalancing.weightCurve.baseline + deficitCurve);
 };
 
 BRAIN.prototype.life = function () {
+  this.profile.simTick += 1;
+  var lowerTierStable = true;
   for ( var i = 0; i < this.thoughts.needs.length; i++) {
     var needs = this.thoughts.needs[i];
+    var tierDeficitPeak = 0;
     for(var j = 0; j< needs.maslow.length;j++){
-      needs.maslow[j].value += 0.01;
-      needs.maslow[j].weight = this.getWeight(needs.maslow[j].baseWeight,needs.maslow[j].value,i);
+      var need = needs.maslow[j];
+      var curve = this.getNeedCurve(need.need);
+      need.value = this.clampNeedValue(need.value + curve.decayPerTick - curve.passiveRecoveryPerTick);
+      var normalizedDeficit = (this.needBalancing.clamp.max - need.value) / this.needBalancing.clamp.max;
+      tierDeficitPeak = Math.max(tierDeficitPeak, normalizedDeficit);
+      var gateMultiplier = this.getTierGateMultiplier(i, lowerTierStable, normalizedDeficit);
+      need.weight = this.getWeight(need.baseWeight, need.value, i) * gateMultiplier;
+      need.weight = Math.max(0, need.weight - this.getNeedCooldownPenalty(need));
     }
+    lowerTierStable = lowerTierStable && tierDeficitPeak <= this.needBalancing.gating.lowerTierDeficitThreshold;
   }
   this.profile.fatigue = Math.min(100, this.profile.fatigue + 0.05);
   if (this.profile.wallet < 10) {
     var moneyNeed = this.findNeedByName('MONEY');
     if (moneyNeed) {
-      moneyNeed.value += 0.5;
-      moneyNeed.weight += 0.2;
+      moneyNeed.value = this.clampNeedValue(moneyNeed.value + 0.5);
     }
   }
   if (this.getCurrentHour() > 21 || this.getCurrentHour() < 6) {
     var warmthNeed = this.findNeedByName('WARMTH');
     if (warmthNeed) {
-      warmthNeed.weight += 0.05;
+      warmthNeed.value = this.clampNeedValue(warmthNeed.value - 0.3);
     }
   }
 };
@@ -823,7 +906,7 @@ BRAIN.prototype.resolveIntent = function (intent) {
     }
     var moneyNeed = this.findNeedByName('MONEY');
     if (moneyNeed && (!settlement || settlement.ok)) {
-      moneyNeed.value = 0;
+      moneyNeed.value = this.clampNeedValue(moneyNeed.value - this.getNeedCurve('MONEY').recoveryOnResolve);
       moneyNeed.emotion = "Wallet's breathing again after that shift";
     }
     if (!settlement || settlement.ok) {
@@ -834,11 +917,21 @@ BRAIN.prototype.resolveIntent = function (intent) {
   if (intent.type === 'FULFILL_NEED' && intent.need) {
     var need = this.findNeedByName(intent.need);
     if (need && (!settlement || settlement.ok)) {
-      need.value = 0;
+      var recovery = this.getNeedCurve(intent.need).recoveryOnResolve;
+      need.value = this.clampNeedValue(need.value - recovery);
       need.emotion = "That helped; the pressure eased for now";
       this.profile.fatigue = Math.max(0, this.profile.fatigue - 2);
+      need.lastServedVenue = intent.door || null;
+      need.lastServedTick = this.profile.simTick;
+      this.profile.venueHistory.push({
+        venue: intent.door || 'unknown',
+        tick: this.profile.simTick
+      });
+      if (this.profile.venueHistory.length > this.needBalancing.cooldown.historyLimit) {
+        this.profile.venueHistory.shift();
+      }
     } else if (need && settlement && !settlement.ok) {
-      need.value += 2;
+      need.value = this.clampNeedValue(need.value + 2);
       this.applyUnmetNeedPressure(intent.need, 2);
       need.emotion = "Didn't get served; still chasing relief";
     }


### PR DESCRIPTION
### Motivation
- Replace ad-hoc, noisy weighting with a predictable, tunable system so dynamic goals across citizens behave consistently. 
- Encode Maslow-tier priorities, per-need decay/recovery, clamping (0–100), gating and cooldowns as data rather than hard-coded values for easy balancing. 

### Description
- Added a balancing data file at `js/data/brainNeedBalancing.json` containing `tierOrder`, `tierUrgency`, global `clamp`, `weightCurve`, per-need `needCurves`, `gating`, and `cooldown` parameters. 
- Load the config in `js/prefabs/Brain.js` and initialize runtime tracking (`profile.simTick`, `profile.venueHistory`) via `initializeNeedRuntimeData`. 
- Replaced the old `getWeight()` formula with a deterministic deficit-based calculation that uses tier urgency and a deficit curve from the config, and added helpers `getTierName`, `clampNeedValue`, and `getNeedCurve`. 
- Reworked `life()` to apply per-need decay/recovery with clamps, compute tier gating/soft-boost behavior, and subtract cooldown penalties from weights to reduce repetitive venue ping-pong. 
- Updated need update paths: `applyUnmetNeedPressure`, `applyFailureState`, and `resolveIntent` now use clamped value adjustments and configured `recoveryOnResolve`, and `resolveIntent` tracks `lastServedVenue` / `lastServedTick` and appends to `profile.venueHistory`. 

### Testing
- Verified the new JSON loads with `node -e "require('./js/data/brainNeedBalancing.json')"`, which succeeded. 
- Verified `js/prefabs/Brain.js` parses by running `node -e "new Function(require('fs').readFileSync('js/prefabs/Brain.js','utf8'))"`, which succeeded. 
- Changes committed to the branch with a descriptive commit message (`Make brain need weighting deterministic and data-driven`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69defed6929c8327940e2fc14a4ead9c)