### PR TITLE
Update Phaser CE to 2.20.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   </style>
 </head>
 <body>
-<script src="static/phaser.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/phaser-ce@2.20.2/build/phaser.min.js"></script>
 <script src="static/bundle.js"></script>
 <script src="//localhost:35729/livereload.js"></script>
 </body>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "imagesloaded": "^5.0.0",
     "ismobilejs": "^1.1.1",
     "jquery.cookie": "^1.4.1",
-    "phaser-ce": "^2.19.0",
+    "phaser-ce": "^2.20.2",
     "picturefill": "^3.0.3"
   },
   "browser": {


### PR DESCRIPTION
### Motivation
- Bump the embedded Phaser CE dependency to a newer patch/minor release and load it from a stable CDN to simplify local vendoring and ensure the project uses Phaser CE 2.20.2.

### Description
- Update `devDependencies.phaser-ce` in `package.json` from `^2.19.0` to `^2.20.2`.
- Replace the local vendored include in `index.html` with a jsDelivr CDN reference to `phaser-ce@2.20.2`.

### Testing
- Ran the validation command `node -e "const p=require('./package.json'); if(p.devDependencies['phaser-ce']!=='^2.20.2') process.exit(1); console.log('phaser-ce',p.devDependencies['phaser-ce']);" && rg -n "phaser-ce@2.20.2|phaser.min.js" index.html` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def78d61048327a43c600819f0dce9)