### PR TITLE
Fix pedestrian hide/show ghosting and sprite flashing

### DIFF
--- a/js/prefabs/Pedestrian.js
+++ b/js/prefabs/Pedestrian.js
@@ -180,17 +180,49 @@ Pedestrian.prototype.removePedestrian = function (next, sprite) {
   if (arrival && arrival.bubbleMessage) {
     sprite.sprite_message = arrival.bubbleMessage;
   }
-  sprite.visible = false;
-  var waitMs = arrival && arrival.waitMs ? arrival.waitMs : Phaser.Timer.SECOND*4;
-  var timer = sprite.game.time.events.add(waitMs, next, sprite);
+
+  if (sprite.move_tween && sprite.move_tween.isRunning) {
+    sprite.move_tween.stop();
+  }
+  sprite.animations.stop();
+  sprite.isMoving = false;
+
+  if (sprite.messageContainer) {
+    sprite.messageContainer.destroy();
+    sprite.messageContainer = null;
+    sprite.messageText = null;
+    sprite.messageBubble = null;
+  }
+
+  sprite.kill();
+
+  var waitMs = arrival && arrival.waitMs ? arrival.waitMs : Phaser.Timer.SECOND * 4;
+  sprite.game.time.events.add(waitMs, next, sprite);
 
 };
 
 Pedestrian.prototype.putBack = function () {
-  this.visible = true;
+  var spawnPadding = 200;
+  this.revive();
+
   this.currentIntent = this.ai.consumeDeferredIntent() || this.ai.chooseIntent();
   this.goal = this.currentIntent.goal;
   this.lastMessage = null;
+  this.isDistracted = false;
+  this.distractionLine = null;
+
+  this.x = (this.goal < this.game.world.centerX) ?
+    this.game.world.width + this.game.rnd.integerInRange(0, spawnPadding) :
+    this.game.world.x - this.game.rnd.integerInRange(0, spawnPadding);
+
+  this.y = this.game.world.height - 260;
+
+  if (!this.isWalking()) {
+    this.anim = this.anim.replace("-wait", "-walk");
+  }
+
+  this.direction = this.setDirection();
+  this.check_animation();
 
 };
 


### PR DESCRIPTION
### Motivation
- Pedestrians hidden with `visible = false` retained active tweens, animations and message UI which produced flashing and ghosting when shown again. 
- The goal is to fully deactivate a pedestrian when removed and restore it in a clean state to avoid leftover render artifacts. 
- Use Phaser lifecycle methods for consistent render/physics handling when temporarily removing and restoring sprites.

### Description
- Stop any active movement tween with `move_tween.stop()` and stop sprite animations with `animations.stop()` when removing a pedestrian. 
- Destroy the pedestrian speech-bubble container immediately to prevent detached/ghost UI by clearing `messageContainer`, `messageText`, and `messageBubble`. 
- Switch the hide/show lifecycle to Phaser `kill()` in `removePedestrian` and `revive()` in `putBack` to ensure consistent internal state. 
- Reinitialize intent/distraction state and respawn the pedestrian off-screen (using a `spawnPadding`) then restart movement via `check_animation()` so the pedestrian re-enters cleanly; changes are in `js/prefabs/Pedestrian.js`.

### Testing
- Ran `npx grunt jshint` against the codebase and the task failed due to pre-existing lint warnings in `js/prefabs/Brain.js`, which are unrelated to this change. 
- Verified there are no new lint errors introduced in `js/prefabs/Pedestrian.js` after the patch. 
- No automated runtime tests were present; changes focus on sprite lifecycle fixes and were implemented in the updated file `js/prefabs/Pedestrian.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df156d65f88327a90c08317673238e)